### PR TITLE
change reference to reserved word "package"

### DIFF
--- a/src/JJJRMISocket.js
+++ b/src/JJJRMISocket.js
@@ -211,9 +211,9 @@ JJJRMISocket.registerClass = function(aClass){
 };
 
 /* for registering all classes returned from generated JS */
-JJJRMISocket.registerPackage = function(package){
-    for (let aClass in package){
-        JJJRMISocket.registerClass(package[aClass]);
+JJJRMISocket.registerPackage = function(packageFile){
+    for (let aClass in packageFile){
+        JJJRMISocket.registerClass(packageFile[aClass]);
     }
 };
 


### PR DESCRIPTION
A small change to rename package to packageFile, since package is a reserved keyword in ES6.